### PR TITLE
Fix xpd-JSON.xsl for generation of projectlist.json

### DIFF
--- a/misc/xpd2/xpd-JSON.xsl
+++ b/misc/xpd2/xpd-JSON.xsl
@@ -8,8 +8,8 @@
 <xsl:output method="text" encoding="utf-8"/>
 
 <xsl:template match="/">
-  <xsl:text>{&#xa;&#x9;"type": "projectlist",&#xa;&#x9;"projects": [</xsl:text>
-  <xsl:text>"&#xa;&#x9;"projects": [</xsl:text>
+  <xsl:text>{&#xa;&#x9;"type": "projectlist",</xsl:text>
+  <xsl:text>&#xa;&#x9;"projects": [</xsl:text>
   <xsl:for-each select="//xpd:project">
     <xsl:apply-templates select="."/>
     <xsl:if test="not(position()=last())"><xsl:text> , </xsl:text></xsl:if>


### PR DESCRIPTION
I tried pulling projectlist.json this morning and found a duplicate "projects": field in it that was breaking JSON decoding.  I tested this fix on the server and it seems to work... but I'm not 100% sure.

This is what the server was returning:
```
{
	"type": "projectlist",
	"projects": ["
	"projects": [{
		"pathname": "lacost",
```