### PR TITLE
Amanda/may 2025 css updates

### DIFF
--- a/misc/esp2/css/large-viewport.css
+++ b/misc/esp2/css/large-viewport.css
@@ -148,8 +148,7 @@
 
 	body:dir(rtl) #Content:not([class]) {
 		width: 75%;
-		margin-right: 22vw;
-		padding-right: 1em;
+		margin-right: 25vw;
 	}
 
 	#Menu {

--- a/misc/esp2/css/large-viewport.css
+++ b/misc/esp2/css/large-viewport.css
@@ -3,77 +3,101 @@
 	.pc05 {
 		width: 05%;
 	}
+
 	.pc10 {
 		width: 10%;
 	}
+
 	.pc15 {
 		width: 15%;
 	}
+
 	.pc20 {
 		width: 20%;
 	}
+
 	.pc25 {
 		width: 25%;
 	}
+
 	.pc30 {
 		width: 30%;
 	}
+
 	.pc35 {
 		width: 35%;
 	}
+
 	.pc40 {
 		width: 40%;
 	}
+
 	.pc45 {
 		width: 45%;
 	}
+
 	.pc50 {
 		width: 50%;
 	}
+
 	.pc55 {
 		width: 65%;
 	}
+
 	.pc60 {
 		width: 70%;
 	}
+
 	.pc65 {
 		width: 65%;
 	}
+
 	.pc70 {
 		width: 70%;
 	}
+
 	.pc75 {
 		width: 75%;
 	}
+
 	.pc80 {
 		width: 80%;
 	}
+
 	.pc85 {
 		width: 85%;
 	}
+
 	.pc90 {
 		width: 90%;
 	}
+
 	.pc95 {
 		width: 95%;
 	}
+
 	.pc100 {
 		width: 100%;
 	}
+
 	ul.biblio {
 		list-style: none;
 		margin-left: 5%;
 		padding-left: 0;
 	}
+
 	ul.biblio li {
 		margin-bottom: 1em;
 	}
+
 	table.pretty {
 		margin: 2em 1em;
 	}
+
 	dl {
 		margin: 1em 2em 1em 2em;
 	}
+
 	#Header {
 		padding: 0px;
 		background: $dark;
@@ -82,6 +106,7 @@
 		border-top: 4px solid $light;
 		border-bottom: 4px solid $light;
 	}
+
 	#HeadTitle {
 		margin: 0px;
 		padding: 0px;
@@ -89,34 +114,44 @@
 		position: relative;
 		top: 0.5em;
 		font-size: 1.6em;
-		color: #ffffff; /* $page */
+		color: #ffffff;
+		/* $page */
 	}
+
 	body:dir(rtl) #HeadTitle {
 		padding-right: 1.5em;
+		vertical-align: middle;
 	}
+
 	#HeadTitle a:link,
 	#HeadTitle a:visited {
-		color: #ffffff; /* $page */
+		color: #ffffff;
+		/* $page */
 		background: $dark;
 		text-decoration: none;
 	}
+
 	#HeadSubtitle {
 		font-style: italic;
 		font-weight: normal;
 		font-size: 1.2em;
-		color: #ffffff; /* $page */
+		color: #ffffff;
+		/* $page */
 	}
+
 	/* without the dd class */
 	#Content:not([class]) {
 		width: 75%;
 		margin-left: 22vw;
 		padding-left: 1em;
 	}
+
 	body:dir(rtl) #Content:not([class]) {
 		width: 75%;
 		margin-right: 22vw;
 		padding-right: 1em;
 	}
+
 	#Menu {
 		float: left;
 		width: 20%;
@@ -125,15 +160,18 @@
 		color: #000;
 		position: relative;
 	}
+
 	#Menu.dd {
 		color: #fff;
 	}
+
 	body:dir(rtl) #Menu {
 		float: right;
 		width: 20vw;
 		padding-right: 1.5em;
 		margin-right: 1em;
 	}
+
 	#MenuCaption {
 		margin-left: 3em;
 		margin-bottom: 0.5em;
@@ -143,22 +181,26 @@
 		width: 70%;
 		border-bottom: 2px solid $light;
 	}
+
 	#Menu ul ul {
 		padding: 0.25em 0 0 4em;
 		margin-bottom: 0.25em;
 		border: 1px solid $light;
 		border-top: 0;
 	}
+
 	#Menu ul ul ul {
 		border-right: 0;
 		padding: 0.25em 0 0 1em;
 	}
+
 	#Menu ul a,
 	ul #SelfInMenu {
 		display: block;
 		padding: 0.35em 1em 0.35em 3em;
 		line-height: normal;
 	}
+
 	#Menu ul ul a,
 	ul ul #SelfInMenu {
 		padding: 0.35em 1em 0.35em 1em;
@@ -168,31 +210,38 @@
 		padding: 0 1em 0 4%;
 		float: left;
 	}
+
 	#ReferenceLinks {
 		padding: 0 4%;
 		text-align: right;
 	}
+
 	#BackToTop {
 		text-align: right;
 		margin: 0 4%;
 	}
+
 	#EndContentSpace {
 		clear: both;
 		height: 1em;
 	}
+
 	#FooterWhole {
 		border-bottom: solid 1px $dark;
 		margin: 0 0 0.2em;
 		clear: both;
 		height: 1em;
 	}
+
 	#FooterLeft {
 		padding: 0 4%;
 	}
+
 	#FooterRight {
 		float: right;
 		padding: 0 4%;
 	}
+
 	#switcherul {
 		margin-left: 3em;
 		margin-bottom: 0.5em;

--- a/misc/esp2/css/print.css
+++ b/misc/esp2/css/print.css
@@ -160,6 +160,10 @@ table.pretty th {
     text-align: left;
 }
 
+body:dir(rtl) table.pretty th {
+    text-align: right;
+}
+
 table.pretty caption {
     margin-left: inherit;
     margin-right: inherit;

--- a/misc/esp2/css/print.css
+++ b/misc/esp2/css/print.css
@@ -1,311 +1,404 @@
 /* revised print stylesheet, April 2014, RAH */
 html {
-font-size: 0.9em;
+    font-size: 0.9em;
 }
+
 body {
-/* width: 100%; */
-margin: 0;
-padding: 0.2em 0 1em 0;
-font-size: 1em;
-font-family: "Palatino Linotype", Palatino, "Times New Roman", Times, serif;
-color: #000000;
-background: #ffffff;
+    /* width: 100%; */
+    margin: 0;
+    padding: 0.2em 0 1em 0;
+    font-size: 1em;
+    font-family: "Palatino Linotype", Palatino, "Times New Roman", Times, serif;
+    color: #000000;
+    background: #ffffff;
 }
+
 code {
-font-family: "Courier New",Courier,mono;
-font-size: 1.2em }
+    font-family: "Courier New", Courier, mono;
+    font-size: 1.2em
+}
+
 ol {
-list-style-type: decimal;
+    list-style-type: decimal;
 }
+
 ol ol {
-list-style-type: lower-alpha;
+    list-style-type: lower-alpha;
 }
+
 ol ol ol {
-list-style-type: lower-roman;
+    list-style-type: lower-roman;
 }
+
 ol ol ol ol {
-list-style-type: upper-alpha;
+    list-style-type: upper-alpha;
 }
+
 pre.listing {
-margin-left: 1em;
-margin-right: 1em;
-padding-top: 5px;
-padding-bottom: 5px;
-padding-left: 2px;
-background-color: #f5f5dc;
-color: black;
+    margin-left: 1em;
+    margin-right: 1em;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 2px;
+    background-color: #f5f5dc;
+    color: black;
 }
+
 pre.example {
-margin-left: 1em;
-margin-right: 1em;
-padding-top: 5px;
-padding-bottom: 5px;
-padding-left: 2px;
-background-color: #eee;
-color: black;
+    margin-left: 1em;
+    margin-right: 1em;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 2px;
+    background-color: #eee;
+    color: black;
 }
+
 pre.cookbook {
-margin-left: 1em;
-margin-right: 1em;
-padding-top: 5px;
-padding-bottom: 5px;
-padding-left: 2px;
-background-color: #daf3e0;
-color: black;
+    margin-left: 1em;
+    margin-right: 1em;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    padding-left: 2px;
+    background-color: #daf3e0;
+    color: black;
 }
+
 td.cookbook {
-background-color: #daf3e0;
-color: black;
-vertical-align: middle;
+    background-color: #daf3e0;
+    color: black;
+    vertical-align: middle;
 }
+
 .cookbook {
-background-color: #daf3e0;
-color: black;
+    background-color: #daf3e0;
+    color: black;
 }
+
 .transcript {
     border: 1px #000000 solid;
     padding: 1em;
 }
+
 .example {
-background-color: #eee;
-color: black;
+    background-color: #eee;
+    color: black;
 }
+
 p.firstpara {
-font-weight: bold;
+    font-weight: bold;
 }
+
 p {
-margin: 0 0 1.3em;
+    margin: 0 0 1.3em;
 }
+
 dt {
     font-weight: bold;
 }
+
 blockquote {
-margin: 0 2em 1.3em;
-font-size: 0.9em;
+    margin: 0 2em 1.3em;
+    font-size: 0.9em;
 }
+
 input {
-font-size: inherit;
+    font-size: inherit;
 }
+
 div.imagefloat {
-margin: 0 0 0.5em 1em;
-float: right;
-clear: right;
-page-break-inside: avoid;
+    margin: 0 0 0.5em 1em;
+    float: right;
+    clear: right;
+    page-break-inside: avoid;
 }
+
 div.imageinline {
-margin: 1em 0;
-page-break-inside: avoid;
+    margin: 1em 0;
+    page-break-inside: avoid;
 }
-div.imageinline img, div.imagefloat img {
-display: block;
-/* commenting out all of the responsive code from screen.css */
-/* keeping the code that KnP uses for print.css */
-/*width:100%;
+
+div.imageinline img,
+div.imagefloat img {
+    display: block;
+    /* commenting out all of the responsive code from screen.css */
+    /* keeping the code that KnP uses for print.css */
+    /*width:100%;
 margin: 0;
 padding: 0;
 max-width:100%; */
 }
+
 img {
-border-width: 0;
+    border-width: 0;
 }
+
 div.imagecaption {
-margin: 0.5em 0 1.25em;
-font-size: 0.9em;
-line-height: normal;
+    margin: 0.5em 0 1.25em;
+    font-size: 0.9em;
+    line-height: normal;
 }
- /* .imagecaption p {
+
+/* .imagecaption p {
 width: 95%;
 } */
 /* Styling for prettier tables. RH 9.7.2009 */
 table.pretty {
-margin: 2em 2em 2em 3em;
-background: #f5f5f5;
-border-collapse: collapse;
+    margin: 2em 2em 2em 3em;
+    background: #f5f5f5;
+    border-collapse: collapse;
 }
-table.pretty th, table.pretty td {
-border: 1px #c0c0c0 solid;
-padding: 0.2em;
+
+table.pretty th,
+table.pretty td {
+    border: 1px #c0c0c0 solid;
+    padding: 0.2em;
 }
+
 table.pretty th {
-background: #dcdcdc;
-text-align: left;
+    background: #dcdcdc;
+    text-align: left;
 }
+
 table.pretty caption {
-margin-left: inherit;
-margin-right: inherit;
+    margin-left: inherit;
+    margin-right: inherit;
 }
+
 form {
-margin: 0;
+    margin: 0;
 }
+
 h1 {
-font-family: Georgia, Times, "Times New Roman", serif;
-margin: 1.5em 0 1.3em;
-font-size: 1.4em;
-line-height: 1.3em;
+    font-family: Georgia, Times, "Times New Roman", serif;
+    margin: 1.5em 0 1.3em;
+    font-size: 1.4em;
+    line-height: 1.3em;
 }
+
 h2 {
-margin: 1.7em 0 0.7em;
-font-size: 1.2em;
-line-height: 1.2em;
+    margin: 1.7em 0 0.7em;
+    font-size: 1.2em;
+    line-height: 1.2em;
 }
+
 h3 {
-margin: 1.7em 0 0.7em;
-font-size: 1.1em;
-line-height: 1.2em;
-font-style: italic;
+    margin: 1.7em 0 0.7em;
+    font-size: 1.1em;
+    line-height: 1.2em;
+    font-style: italic;
 }
-li h2, li h3 {
-margin-top: 0;
+
+li h2,
+li h3 {
+    margin-top: 0;
 }
-span.glossarylink, span.techtermslink, span.indexlink, span.switcherlink {
-display: none;
+
+span.glossarylink,
+span.techtermslink,
+span.indexlink,
+span.switcherlink {
+    display: none;
 }
+
 a:link {
-color: #000000;
+    color: #000000;
 }
+
 a:visited {
-color: #000000;
+    color: #000000;
 }
+
 #AccessLinks {
-display: none;
+    display: none;
 }
+
 #Banner {
-width: 100%;
-text-align: center;
+    width: 100%;
+    text-align: center;
 }
+
 #Breadcrumb {
-display: none;
+    display: none;
 }
+
 #TextSize {
-display: none;
+    display: none;
 }
+
 #CuneiformSwitcher {
-display: none;
+    display: none;
 }
+
 #Header {
-border-bottom: 1px solid #000000;
-margin: 0 1em;
+    border-bottom: 1px solid #000000;
+    margin: 0 1em;
 }
-#HeadTitle a:link, #HeadTitle a:visited {
-text-decoration: none;
+
+#HeadTitle a:link,
+#HeadTitle a:visited {
+    text-decoration: none;
 }
+
 #HeadSubtitle {
-font-weight: normal;
+    font-weight: normal;
 }
+
 #Search {
-display: none;
+    display: none;
 }
+
 #Menu {
-display: none;
+    display: none;
 }
+
 #ReferenceLinks {
-display: none;
+    display: none;
 }
+
 #StyleSheetWarning {
-display: none;
+    display: none;
 }
+
 #Content {
     margin: 2em;
 }
+
 #SiteMap a {
-text-decoration: none;
+    text-decoration: none;
 }
+
 #SiteMap ul {
-margin: 0;
-padding-left: 2em;
-list-style: none;
+    margin: 0;
+    padding-left: 2em;
+    list-style: none;
 }
-#SiteMap > ul {
-padding-left: 0;
+
+#SiteMap>ul {
+    padding-left: 0;
 }
+
 #SiteMap h2 {
-margin: 0.3em 0;
+    margin: 0.3em 0;
 }
+
 #SiteMap h3 {
-margin: 0.2em 0;
+    margin: 0.2em 0;
 }
+
 #SiteMap div {
-margin: 0.1em 0;
+    margin: 0.1em 0;
 }
+
 #AccessKeys {
-border: 0;
-margin: 0 1em;
-padding: 0;
+    border: 0;
+    margin: 0 1em;
+    padding: 0;
 }
-#AccessKeys th, #AccessKeys td {
-padding: 0 1em;
-text-align: left;
+
+#AccessKeys th,
+#AccessKeys td {
+    padding: 0 1em;
+    text-align: left;
 }
+
 #AccessKeys th {
-border-bottom: solid 2px #000000;
+    border-bottom: solid 2px #000000;
 }
+
 #AccessKeys tr.odd {
-background: #dcdcdc;
+    background: #dcdcdc;
 }
-#Index h2, #Glossary h2, #Techterms h2 {
-float: left;
-margin: 0;
-color: #ccc;
+
+#Index h2,
+#Glossary h2,
+#Techterms h2 {
+    float: left;
+    margin: 0;
+    color: #ccc;
 }
+
 #Vocablist h2 {
-margin: 0;
-line-height: 1.3em;
-color: #000000;
+    margin: 0;
+    line-height: 1.3em;
+    color: #000000;
 }
+
 #Vocablist h2.empty {
-margin: 0 0 2.5em;
-line-height: 1.3em;
-color: #ccc;
+    margin: 0 0 2.5em;
+    line-height: 1.3em;
+    color: #ccc;
 }
-#Index h3, #Glossary dl, #Techterms dl {
-margin: 0 0 0 3em;
+
+#Index h3,
+#Glossary dl,
+#Techterms dl {
+    margin: 0 0 0 3em;
 }
-#Index ul, #Vocablist ul {
-list-style-type: none;
-margin: 0 0 1em 4em;
-padding: 0;
+
+#Index ul,
+#Vocablist ul {
+    list-style-type: none;
+    margin: 0 0 1em 4em;
+    padding: 0;
 }
+
 #Glossary dt {
-font-weight: bold;
+    font-weight: bold;
 }
+
 #Techterms dt {
-font-weight: bold;
+    font-weight: bold;
 }
+
 #Authors {
-clear: both;
-border-top: dotted 1px #000;
-margin: 2.5em 0 0;
-padding: 1em 0 0;
-font-style: italic;
-font-size: 0.9em;
+    clear: both;
+    border-top: dotted 1px #000;
+    margin: 2.5em 0 0;
+    padding: 1em 0 0;
+    font-style: italic;
+    font-size: 0.9em;
+
+    &:not(body:dir(rtl)) {
+        font-style: italic;
+    }
 }
+
 #CiteAs {
-font-size: 0.9em;
+    font-size: 0.9em;
 }
+
 #Alphabet {
-display: none;
+    display: none;
 }
+
 #BackToTop {
-display: none;
+    display: none;
 }
+
 #EndContentSpace {
-clear: both;
-height: 1em;
+    clear: both;
+    height: 1em;
 }
+
 #FooterWhole {
-border-bottom: solid 1px #000000;
-clear: both;
-height: 1em;
+    border-bottom: solid 1px #000000;
+    clear: both;
+    height: 1em;
 }
+
 #FooterLeft {
-padding: 0 1em;
+    padding: 0 1em;
 }
+
 #FooterRight {
-display: none;
+    display: none;
 }
+
 #PageLinks {
-display: none;
+    display: none;
 }
+
 #URL {
-margin: 0 1em;
+    margin: 0 1em;
 }

--- a/misc/esp2/css/print.css
+++ b/misc/esp2/css/print.css
@@ -186,7 +186,10 @@ h3 {
     margin: 1.7em 0 0.7em;
     font-size: 1.1em;
     line-height: 1.2em;
-    font-style: italic;
+
+    &:not(body:dir(rtl)) {
+        font-style: italic;
+    }
 }
 
 li h2,

--- a/misc/esp2/css/screen.css
+++ b/misc/esp2/css/screen.css
@@ -113,6 +113,7 @@ div.imagefloat {
 	clear: right;
 	page-break-inside: avoid;
 }
+
 body:dir(rtl) .imagefloat {
 	float: left;
 	clear: left;
@@ -129,7 +130,8 @@ div.imagefloat img {
 	display: block;
 	/* This width:100% is needed to make images grow to the width of their grid div; */
 	/* If used with inline images it makes all images 100% instead of respecting the grid class */
-	/*width:100%;*/ /* Commented out sjt 20191223 */
+	/*width:100%;*/
+	/* Commented out sjt 20191223 */
 	margin: 0;
 	padding: 0;
 	max-width: 100%;
@@ -193,11 +195,13 @@ h1 {
 	line-height: 1.3em;
 	margin: 1.5em 0 1.3em;
 }
+
 h2 {
 	font-size: 1.1em;
 	line-height: 1.2em;
 	margin: 1.7em 0 0.7em;
 }
+
 h3 {
 	font-size: 1em;
 	line-height: 1.1em;
@@ -279,6 +283,7 @@ a:visited:hover {
 	width: 100%;
 	text-align: center;
 }
+
 #Content,
 #Content.dd {
 	margin-inline: 2.5em;
@@ -288,11 +293,13 @@ a:visited:hover {
 #Menu a {
 	text-decoration: none;
 }
+
 #Menu a.open:hover,
 #Menu a.closed:hover {
 	color: $medium;
 	background-color: $light;
 }
+
 #Menu a.open {
 	background: $light;
 }
@@ -304,11 +311,13 @@ a:visited:hover {
 	background: #fff;
 	list-style-type: none;
 }
+
 /* this is for displaying the dropdown */
 #Menu.dd ul {
 	display: none;
 	position: absolute;
 }
+
 #Menu.dd:hover ul {
 	display: block;
 	position: absolute;
@@ -322,6 +331,7 @@ a:visited:hover {
 	list-style-image: url(/img/blank.gif);
 	/* IE Win does weird stuff with list-style-type: none */
 }
+
 #Menu li.only {
 	font-weight: normal;
 }
@@ -329,14 +339,12 @@ a:visited:hover {
 #SelfInMenu {
 	font-weight: bold;
 }
+
 #SelfInMenu.open {
 	background-color: $light;
 }
 
-@file small-viewport.css
-@file large-viewport.css
-
-#Search {
+@file small-viewport.css @file large-viewport.css #Search {
 	float: right;
 	padding: 0.5em 6em 0.5em 1em;
 	margin: 0.3em 0 0 -3px;
@@ -346,7 +354,8 @@ a:visited:hover {
 
 #Search label {
 	font-weight: bold;
-	color: #ffffff; /* $page */
+	color: #ffffff;
+	/* $page */
 }
 
 #StyleSheetWarning {
@@ -363,7 +372,7 @@ a:visited:hover {
 	list-style: none;
 }
 
-#SiteMap > ul {
+#SiteMap>ul {
 	padding-left: 0;
 }
 
@@ -392,11 +401,13 @@ a:visited:hover {
 }
 
 #AccessKeys th {
-	border-bottom: solid 2px #333333; /* $text */
+	border-bottom: solid 2px #333333;
+	/* $text */
 }
 
 #AccessKeys tr.odd {
-	background: #eeeeee; /* $alternate */
+	background: #eeeeee;
+	/* $alternate */
 }
 
 #Index h2,
@@ -410,7 +421,8 @@ a:visited:hover {
 #Vocablist h2 {
 	margin: 0;
 	line-height: 1.3em;
-	color: #333333; /* $text */
+	color: #333333;
+	/* $text */
 }
 
 #Vocablist h2.empty {
@@ -445,8 +457,11 @@ a:visited:hover {
 	border-top: dotted 1px $dark;
 	margin: 2.5em 0 0;
 	padding: 1em 0 0;
-	font-style: italic;
 	font-size: 0.9em;
+
+	&:not(body:dir(rtl)) {
+		font-style: italic;
+	}
 }
 
 #CiteAs {

--- a/misc/esp2/css/screen.css
+++ b/misc/esp2/css/screen.css
@@ -166,6 +166,10 @@ table.pretty th {
 	font-weight: normal;
 }
 
+body:dir(rtl) table.pretty th {
+	text-align: right;
+}
+
 table.pretty caption {
 	margin-left: inherit;
 	margin-right: inherit;

--- a/misc/esp2/css/screen.css
+++ b/misc/esp2/css/screen.css
@@ -207,7 +207,10 @@ h3 {
 	line-height: 1.1em;
 	margin: 1.7em 0 0.7em;
 	font-weight: normal;
-	font-style: italic;
+
+	&:not(body:dir(rtl)) {
+		font-style: italic;
+	}
 }
 
 li h2,


### PR DESCRIPTION
Addresses the following:
> Space above text in the top banner: could you add a few pixels more please? It feels to me as though the spacing above and below the year dates should be more symmetrical
No italics: <esp:author> and <esp:sh> display as italic in the English version of ESP. But italics aren’t generally used in Arabic script, so I would like:
<esp:author> as plain text
<esp:sh> i.e., subheadings, as bold, but smaller than <esp:h> headings. That may mean increasing the size of <esp:h> slightly
Text wrapping around menu: The main text seems to wrap slightly around the right-hand menu, in a way that it doesn’t on the English version. (e.g., but not only,  [https://build-oracc.museum.upenn.edu/kish/mathaffield/kish-mhm/bilad-ma-bein-annahrein/index.html](https://eur01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fbuild-oracc.museum.upenn.edu%2Fkish%2Fmathaffield%2Fkish-mhm%2Fbilad-ma-bein-annahrein%2Findex.html&data=05%7C02%7Ca.ho-lyn%40ucl.ac.uk%7Ccb064412a1764b82b07808dd88b2f929%7C1faf88fea9984c5b93c9210a11d9a5c2%7C0%7C0%7C638817024455283151%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=HbKi1rL0qGx7bg2Y%2BgmBAQF%2BOfcMKGuRsnYU2nylg%2Fg%3D&reserved=0)). Can that be fixed?
Table heads <th>: Could these be right-justified please?