### PR TITLE
moving script into xsl because library.js returns 404

### DIFF
--- a/misc/esp2/esp2-head.xsl
+++ b/misc/esp2/esp2-head.xsl
@@ -212,6 +212,18 @@
   gtag('js', new Date());
 
   gtag('config', 'G-0QKC3P5HJ1');
+
+  function addMenuListener() {
+	let menubutton = document.querySelector("#menu-button");
+	if (menubutton) {
+		menubutton.addEventListener("click", function () {
+			var menu = document.querySelector("#Menu");
+			menu.classList.toggle("hidden");
+		});
+	}
+}
+
+addMenuListener();
 </script>
 </xsl:template>
 

--- a/misc/esp2/js/library.js
+++ b/misc/esp2/js/library.js
@@ -5,16 +5,6 @@ function doOnLoad() {
 	unobfuscateEmailSpans();
 }
 
-function addMenuListener() {
-	let menubutton = document.querySelector("#menu-button");
-	if (menubutton) {
-		menubutton.addEventListener("click", function () {
-			var menu = document.querySelector("#Menu");
-			menu.classList.toggle("hidden");
-		});
-	}
-}
-
 /*
 Highlighting for elements related to an active anchor tag
 */


### PR DESCRIPTION
fetching library.js actually returns a 404, so moving the function into the xsl

<img width="298" alt="image" src="https://github.com/user-attachments/assets/7a91ef30-b2b4-4128-9a74-0528add0c7c8" />
